### PR TITLE
v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
-## [Beta Version 3.3.2](https://github.com/OpenWonderLabs/homebridge-switchbot-openapi/compare/v3.3.1...v3.3.2) (2021-02-25)
+## [Version 3.3.2](https://github.com/OpenWonderLabs/homebridge-switchbot-openapi/compare/v3.3.1...v3.3.2) (2021-02-25)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Beta Version 3.3.2](https://github.com/OpenWonderLabs/homebridge-switchbot-openapi/compare/v3.3.1...v3.3.2) (2021-02-25)
+
+### Changes
+
+- Fix issue where curtain refreshRate was being required when it's not required.
+
 ## [Version 3.3.1](https://github.com/OpenWonderLabs/homebridge-switchbot-openapi/compare/v3.3.0...v3.3.1) (2021-02-25)
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "homebridge-switchbot-openapi",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge SwitchBot OpenAPI",
   "name": "homebridge-switchbot-openapi",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "The [Homebridge](https://homebridge.io) SwitchBot plugin allows you to access your [SwitchBot](https://www.switch-bot.com) device(s) from HomeKit.",
   "author": "SwitchBot <support@wondertechlabs.com> (https://github.com/SwitchBot)",
   "license": "ISC",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -145,7 +145,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         this.config.options.curtain.set_max;
 
         if (!this.config.options.curtain.refreshRate) {
-          this.config.options!.curtain.refreshRate = 5;
+          this.config.options!.curtain!.refreshRate! = 5;
           this.log.debug('Using Default Curtain Refresh Rate.');
         }
       }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -145,8 +145,8 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         this.config.options.curtain.set_max;
 
         if (!this.config.options.curtain.refreshRate) {
-          // default 300 seconds
-          this.config.options!.curtain.refreshRate! = 5;
+          this.config.options!.curtain.refreshRate = 5;
+          this.log.debug('Using Default Curtain Refresh Rate.');
         }
       }
 


### PR DESCRIPTION
## [Version 3.3.2](https://github.com/OpenWonderLabs/homebridge-switchbot-openapi/compare/v3.3.1...v3.3.2) (2021-02-25)

### Changes

- Fix issue where curtain refreshRate was being required when it's not required.